### PR TITLE
ci: lint:fix after changeset version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - run: npm ci
       - uses: changesets/action@v1
         with:
-          version: npx changeset version && npm run lint:fix
+          version: npm run version
           publish: npm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "typecheck": "tsc --noEmit",
     "vscode:prepublish": "npm run compile",
     "watch": "tsc -watch",
+    "version": "npx changeset version && npm run lint:fix",
     "release": "node scripts/tag-extension.mjs && npx vsce publish"
   },
   "contributes": {


### PR DESCRIPTION
fix Release error
> 🦋  error Too many arguments passed to changesets - we only accept the command name as an argument